### PR TITLE
Bug to open device

### DIFF
--- a/src/pynanovna/pynanovna.py
+++ b/src/pynanovna/pynanovna.py
@@ -22,6 +22,7 @@ class NanoVNAWorker:
         self.playback_mode = False
         try:
             self.iface = hw.get_interfaces()[vna_index]
+            self.iface.open()
         except IndexError:
             print("NanoVNA not found, is it connected? Entering playback mode.")
             self.playback_mode = True


### PR DESCRIPTION
I am unable to open the nanovna unless I write self.iface.open() after the self.iface definition. Maybe I am missing something, but just in case.